### PR TITLE
Update sidebar icons to match tab names

### DIFF
--- a/components/modules/website/account/SidebarAccount.tsx
+++ b/components/modules/website/account/SidebarAccount.tsx
@@ -4,12 +4,9 @@ import { cn } from "@/lib/utils";
 import { User as TUser } from "@/types";
 import {
   AlignJustify,
-  BadgeDollarSign,
-  BookUser,
-  LayoutDashboard,
   LogOut,
-  User,
 } from "lucide-react";
+import { MdSettings } from "react-icons/md";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -58,7 +55,7 @@ export default function SidebarAccount({ user }: { user: TUser }) {
                 className="flex items-center p-2 text-gray-900 rounded-lg"
                 href="/account/dashboard"
               >
-                <LayoutDashboard />
+                <MdSettings />
                 <span className="ms-3">Dashboard</span>
               </Link>
             </li>
@@ -68,7 +65,7 @@ export default function SidebarAccount({ user }: { user: TUser }) {
                 className="flex items-center p-2 text-gray-900 rounded-lg"
                 href="/account/profil"
               >
-                <User />
+                <MdSettings />
                 <span className="ms-3">Profil</span>
               </Link>
             </li>
@@ -78,7 +75,7 @@ export default function SidebarAccount({ user }: { user: TUser }) {
                 className="flex items-center p-2 text-gray-900 rounded-lg"
                 href="/account/order"
               >
-                <BadgeDollarSign />
+                <MdSettings />
                 <span className="ms-3">Order</span>
               </Link>
             </li>
@@ -88,7 +85,7 @@ export default function SidebarAccount({ user }: { user: TUser }) {
                 className="flex items-center p-2 text-gray-900 rounded-lg"
                 href="/account/address"
               >
-                <BookUser />
+                <MdSettings />
                 <span className="ms-3">Address</span>
               </Link>
             </li>


### PR DESCRIPTION

This pull request includes changes to the `SidebarAccount` component in the `components/modules/website/account/SidebarAccount.tsx` file. The changes primarily involve replacing several icons with a new icon from the `react-icons` library.

Icon replacements:

* Replaced `LayoutDashboard`, `User`, `BadgeDollarSign`, and `BookUser` icons with `MdSettings` from `react-icons/md`. [[1]](diffhunk://#diff-fea4ca341f761672cc70c2cd7187dfc513136473cbb3ec66ff206d84f487d3acL61-R58) [[2]](diffhunk://#diff-fea4ca341f761672cc70c2cd7187dfc513136473cbb3ec66ff206d84f487d3acL71-R68) [[3]](diffhunk://#diff-fea4ca341f761672cc70c2cd7187dfc513136473cbb3ec66ff206d84f487d3acL81-R78) [[4]](diffhunk://#diff-fea4ca341f761672cc70c2cd7187dfc513136473cbb3ec66ff206d84f487d3acL91-R88)

Import adjustments:

* Removed unused imports `BadgeDollarSign`, `BookUser`, `LayoutDashboard`, and `User` from `lucide-react`. Added import for `MdSettings` from `react-icons/md`.